### PR TITLE
Read response_mode from query param

### DIFF
--- a/lib/request/extensions.js
+++ b/lib/request/extensions.js
@@ -26,6 +26,9 @@ module.exports = function() {
     if (q.web_message_target) {
       ext.webMessageTarget = q.web_message_target;
     }
+    if (q.response_mode) {
+      ext.responseMode = q.response_mode;
+    }
     
     return ext;
   }


### PR DESCRIPTION
To handle the web_message authorize request Oauth2orize reads the responseMode from session transaction. So to make it work properly we should add web_message response mode in transaction. 


- [x] I have read the [CONTRIBUTING](https://github.com/jaredhanson/oauth2orize-wmrm/blob/master/CONTRIBUTING.md) guidelines.
- [ ] I have added test cases which verify the correct operation of this feature or patch.
- [ ] I have added documentation pertaining to this feature or patch.
- [ ] The automated test suite (`$ make test`) executes successfully.
- [x] The automated code linting (`$ make lint`) executes successfully.
